### PR TITLE
Allow django 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     include_package_data=True,
     python_requires='>=3.6',
     install_requires=[
-        'django>=2.1,<4.0',
+        'django>=2.1,<4.1',
         'dataclasses>=0.7; python_version < "3.7.0"',
     ],
     extras_require={


### PR DESCRIPTION
There is no indication of incompatibility with django 4.0