### PR TITLE
restore register_all_views on app.ready

### DIFF
--- a/django_orm_views/apps.py
+++ b/django_orm_views/apps.py
@@ -7,4 +7,6 @@ class DjangoPostgresViewsConfig(AppConfig):
 
     name = 'django_orm_views'
     app_label = 'django_orm_views'
-
+    
+    def ready(self):
+        register_all_views()


### PR DESCRIPTION
https://github.com/iwoca/django-orm-views/commit/3f8952d118774b11e64db5223afe4d987a2bf4cb

moved the call to `register_all_views` inside `sync_views`. This means that the views are not available after the app is loaded.

This MR restores the original call to register_all_views . It is unclear the rationale to call this function inside sync_views but there is no harm on calling register_all_views twice